### PR TITLE
Fixed CGPath generation errors

### DIFF
--- a/JESCircularProgressView/Classes/JESCircularProgressView.m
+++ b/JESCircularProgressView/Classes/JESCircularProgressView.m
@@ -169,6 +169,12 @@ static const CGFloat JESDefaultProgressLineWidth = 4;
 		                                               round(self.progressLineWidth + self.outerLineWidth),
 		                                               round(self.progressLineWidth + self.outerLineWidth)));
 	}
+	if (!isnormal(progressLineInset.origin.x) ||
+		!isnormal(progressLineInset.origin.y) ||
+		!isnormal(progressLineInset.size.width) ||
+		!isnormal(progressLineInset.size.height)) {
+		progressLineInset = CGRectZero;
+	}
 	return progressLineInset;
 }
 


### PR DESCRIPTION
When the path was created in a view with an empty rect some points would have NaN, +Inf or -Inf values. See issue #3
